### PR TITLE
Implement Markdown correction mechanism

### DIFF
--- a/resources/test/core.md
+++ b/resources/test/core.md
@@ -84,3 +84,10 @@ This is a H1 heading with settext
 
 And this is a H2 heading with settext
 -------------------------------------
+
+Testing paragraph right before a code block
+```
+code goes here
+```
+# Heading goes here
+Paragraph right after heading

--- a/resources/test/core_result.html
+++ b/resources/test/core_result.html
@@ -59,3 +59,11 @@ function markdownToHTML(markdown) {
 <h1>This is a H1 heading with settext</h1>
 
 <h2>And this is a H2 heading with settext</h2>
+
+<p>Testing paragraph right before a code block</p>
+
+<pre><code>code goes here</code></pre>
+
+<h1>Heading goes here</h1>
+
+<p>Paragraph right after heading</p>

--- a/src/clarktown/core.clj
+++ b/src/clarktown/core.clj
@@ -25,3 +25,6 @@
    (render markdown parsers/parsers))
   ([markdown given-parsers]
    (parser/parse markdown given-parsers)))
+
+(comment
+  (render (slurp "./test.md")))

--- a/src/clarktown/parsers/code_block.clj
+++ b/src/clarktown/parsers/code_block.clj
@@ -16,13 +16,15 @@
   (let [language (->> block
                       (re-find #"\`\`\`(\w+)")
                       second)
-        code (as-> block n
-                   (string/replace-first n #"\`\`\`(\w+)?\n" "")
-                   (subs n 0 (- (count n) 4))
-                   (string/replace n #"&" "&amp;")
-                   (string/replace n #"<" "&lt;")
-                   (string/replace n #">" "&gt;")
-                   (string/trim n))]
+        lines (string/split-lines block)
+        block* (->> (next lines)
+                    (take (- (count lines) 2))
+                    (string/join \newline))
+        code (-> block*
+                 (string/replace #"&" "&amp;")
+                 (string/replace #"<" "&lt;")
+                 (string/replace #">" "&gt;")
+                 string/trim)]
     (if language
       (str "<pre><code class=\"language-" language "\">" code "</code></pre>")
       (str "<pre><code>" code "</code></pre>"))))


### PR DESCRIPTION
This fixes the issue for ATX headings and code blocks where if there were no empty lines below and above of them it couldn't correctly identify those blocks as what they were.

There's now a Markdown correction function where we can add more of these corrections in the future, making the whole thing a lot easier.

Fixes #13 
Fixes #14 