### PR TITLE
Support rendering of images with an empty alt

### DIFF
--- a/src/clarktown/renderers/link_and_image.clj
+++ b/src/clarktown/renderers/link_and_image.clj
@@ -13,7 +13,7 @@
   "Renders all occurring links and images."
   [block _ _]
   (loop [block block
-         matches (-> (re-seq #"\!?\[([a-zA-Z0-9\-\_\.\,\']+( [a-zA-Z0-9\-\_\.\,\']+)*)\]\((.*?)\)" block)
+         matches (-> (re-seq #"\!?\[([a-zA-Z0-9\-\_\.\,\']*( [a-zA-Z0-9\-\_\.\,\']+)*)\]\((.*?)\)" block)
                      distinct)]
     (if (empty? matches)
       block

--- a/test/clarktown/renderers/link_and_image_test.clj
+++ b/test/clarktown/renderers/link_and_image_test.clj
@@ -20,4 +20,7 @@
 
   (testing "Creating an image"
     (is (= (link-and-image/render "![This is an image](https://example.com)" nil nil)
-           "<img src=\"https://example.com\" alt=\"This is an image\">"))))
+           "<img src=\"https://example.com\" alt=\"This is an image\">"))
+
+    (is (= (link-and-image/render "![](https://example.com)" nil nil)
+           "<img src=\"https://example.com\" alt=\"\">"))))


### PR DESCRIPTION
Hi, first of all thanks for creating this great library! I love the no dependency approach.

This is a small fix that supports rendering links and images without an `alt`. With this change, the following will work:

```
(clarktown/render "![](https://example.com)")
"<p><img src=\"https://example.com\" alt=\"\"></p>"
```

I believe that to be the expected behavior of a markdown parser.
